### PR TITLE
mongodb: return null when the user is not found when getting user

### DIFF
--- a/src/scripts/mongo/get_user.js
+++ b/src/scripts/mongo/get_user.js
@@ -12,6 +12,7 @@ function getByEmail(email, callback) {
       client.close();
 
       if (err) return callback(err);
+      if (!user) return callback(null, null);
 
       return callback(null, {
         user_id: user._id.toString(),

--- a/test/scripts/mongo/get_user.test.js
+++ b/test/scripts/mongo/get_user.test.js
@@ -62,4 +62,20 @@ describe(scriptName, () => {
       done();
     });
   });
+
+  it('should return null', (done) => {
+    findOne.mockImplementation((query, callback) => {
+      expect(query.email).toEqual('duck.t@example.com');
+
+      return callback(null, null);
+    });
+
+    const expectedUser = null;
+
+    script('duck.t@example.com', (err, user) => {
+      expect(err).toBeFalsy();
+      expect(user).toEqual(expectedUser);
+      done();
+    });
+  });
 });


### PR DESCRIPTION
### Description

This PR updates the `Get User` template script for MongoDB in `Custom Database` under ` Database Connections`.

Previously the template script does not check if the user is found in the database and proceeds to parsing the `null` user object and errors out when attempt reading the `_id` property.

The updated PR updates the template to check if the user is found, and calls the callback function with a `null` user object if the user is not found.

### References

- https://community.auth0.com/t/custom-database-mongodb-altas-script-template-in-signup-user-doesnt-get-created-get-an-error/23474

### Testing

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
