### PR TITLE
Fix(mongo): verify / resetPassword use writeResult

### DIFF
--- a/src/scripts/mongo/change_password.js
+++ b/src/scripts/mongo/change_password.js
@@ -15,10 +15,10 @@ function changePassword(email, newPassword, callback) {
         return callback(err);
       }
 
-      users.update({ email: email }, { $set: { password: hash } }, function (err, count) {
+      users.update({ email: email }, { $set: { password: hash } }, function (err, writeResult) {
         client.close();
         if (err) return callback(err);
-        callback(null, count > 0);
+        callback(null, writeResult.result.nModified > 0);
       });
     });
   });

--- a/src/scripts/mongo/verify.js
+++ b/src/scripts/mongo/verify.js
@@ -9,11 +9,11 @@ function verify (email, callback) {
     const users = db.collection('users');
     const query = { email: email, email_verified: false };
 
-    users.update(query, { $set: { email_verified: true } }, function (err, count) {
+    users.update(query, { $set: { email_verified: true } }, function (err, writeResult) {
       client.close();
 
       if (err) return callback(err);
-      callback(null, count > 0);
+      callback(null, writeResult.result.nModified > 0);
     });
   });
 }


### PR DESCRIPTION
### Description

Consider default verify / change password templates for mongo. Let's add console.log before each of the callback executions to log `count > 0` check result into console, and hit 'Save & Try'.

Script for verify:
```
   users.update(query, { $set: { email_verified: true } }, function (err, count) {
      client.close();
        console.log(err, count > 0);
      if (err) return callback(err);
      callback(null, count > 0);
    });
```

Produces:

<img width="1035" alt="Screen Shot 2021-11-19 at 1 18 49 PM" src="https://user-images.githubusercontent.com/8777372/142672635-55f8536e-b9aa-4397-a72b-d687bd548094.png">

🤔 ❓ ❓ ❓

Script for change password:

```
   users.update({ email: email }, { $set: { password: hash } }, function (err, count) {
        client.close();
        console.log(err, count > 0);
        if (err) return callback(err);
        callback(null, count > 0);
      });
```

Produces:

<img width="988" alt="Screen Shot 2021-11-19 at 1 17 54 PM" src="https://user-images.githubusercontent.com/8777372/142672626-e1c73d09-8094-4989-84ba-8bcffd1dee45.png">

As we can see, `count > 0` results in `false`, however manhattan happily tells us everything works as it should. This is not true 🥶. 
If we change console.log to dump the whole `count` variable, we see:

<img width="1032" alt="Screen Shot 2021-11-19 at 1 19 21 PM" src="https://user-images.githubusercontent.com/8777372/142674579-9fd94c17-cbfc-4773-9251-b0d5f1f503e5.png">


### Explanation

Mongo doc tells us, that update() call returns WriteResult object, with the result.nModified property, which is meant to be used here most likely.
https://docs.mongodb.com/manual/reference/method/db.collection.update/#std-label-writeresults-update
But it's also the `Try` script which works incorrectly. Luckily, real auth0-users code executes and checks results correctly and throws an error, if second callback parameter is false in these scripts.

### Fix
One part is this fix for templates. Other part should happen in code which implements the `Try` and `Save & Try` functionality.
