### PR TITLE
[IUM-1599]Mongo template fix for verify and change_password

### DIFF
--- a/src/scripts/mongo/change_password.js
+++ b/src/scripts/mongo/change_password.js
@@ -15,10 +15,10 @@ function changePassword(email, newPassword, callback) {
         return callback(err);
       }
 
-      users.update({ email: email }, { $set: { password: hash } }, function (err, count) {
+      users.update({ email: email }, { $set: { password: hash } }, function (err, result) {
         client.close();
         if (err) return callback(err);
-        callback(null, count > 0);
+        callback(null, result.result.n > 0);
       });
     });
   });

--- a/src/scripts/mongo/verify.js
+++ b/src/scripts/mongo/verify.js
@@ -9,11 +9,11 @@ function verify (email, callback) {
     const users = db.collection('users');
     const query = { email: email, email_verified: false };
 
-    users.update(query, { $set: { email_verified: true } }, function (err, count) {
+    users.update(query, { $set: { email_verified: true } }, function (err, result) {
       client.close();
 
       if (err) return callback(err);
-      callback(null, count > 0);
+      callback(null, result.result.n > 0);
     });
   });
 }

--- a/test/scripts/mongo/change_password.test.js
+++ b/test/scripts/mongo/change_password.test.js
@@ -51,13 +51,31 @@ describe(scriptName, () => {
     });
   });
 
+  it('should return false, if user not found', (done) => {
+    update.mockImplementation((query, data, callback) => callback(null, {
+      result: {
+        n: 0,
+      },
+    }));
+
+    script('broken@example.com', (err, success) => {
+      expect(err).toBeFalsy();
+      expect(success).toEqual(false);
+      done();
+    });
+  });
+
   it('should update hashed password', (done) => {
     update.mockImplementation((query, data, callback) => {
       expect(query.email).toEqual('duck.t@example.com');
       expect(typeof data.$set.password).toEqual('string');
       expect(data.$set.password.length).toEqual(60);
 
-      return callback(null, 1);
+      return callback(null, {
+        result: {
+          n: 1,
+        },
+      });
     });
 
     script('duck.t@example.com', 'newPassword', (err, success) => {

--- a/test/scripts/mongo/verify.test.js
+++ b/test/scripts/mongo/verify.test.js
@@ -44,7 +44,11 @@ describe(scriptName, () => {
   });
 
   it('should not update user, if email already validated', (done) => {
-    update.mockImplementation((query, data, callback) => callback(null, 0));
+    update.mockImplementation((query, data, callback) => callback(null, {
+      result: {
+        n: 0,
+      },
+    }));
 
     script('validated@example.com', (err, success) => {
       expect(err).toBeFalsy();
@@ -59,7 +63,11 @@ describe(scriptName, () => {
       expect(query.email_verified).toEqual(false);
       expect(data.$set.email_verified).toEqual(true);
 
-      callback(null, 1)
+      callback(null, {
+        result: {
+          n: 1,
+        },
+      })
     });
 
     script('duck.t@example.com', (err, success) => {


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

Fix to correctly utilize the callback result from Mongo.

Note: In a future effort I think we should perhaps re-think some of the templates, docs, and guard code in auth0-users for some of these scripts.  See link below for some limited testing and notes.  But for now we are just looking to fix these broken templates.

### References

https://oktawiki.atlassian.net/wiki/spaces/~5cf47b12c756c10f35f287b7/pages/2670986844/Verify+and+Password+Change+Script+Callback+Behavior

https://auth0team.atlassian.net/browse/IUM-1599


### Testing

- [X] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
